### PR TITLE
Support documentation reference (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,36 +44,39 @@ This annotation can be used to annotate fields and represents one property in a 
 The following matrix gives an overview about the arguments for this annotation:
 | Name | Type | Default value | Optional | Description |
 |-|:-:|:-:|:-:|-|
-|label			|String		|""		|✔️|The label that will be displayed in the Modeler.|
-|type			|String		|		|❌|The property type, e.g. String, Hidden, Dropdown.|
-|value			|String		|""		|✔️|The default value selected in the Modeler.|
-|choices		|@Choice[]	|{}		|✔️|An array containing the choices available in a Dropdown menu.|
-|description	|String		|""		|✔️|The description that is shown at the entry in the Modeler.|
-|parameterType	|String		|"input"|✔️|The parameter type of the property, available options are: "input", "output", "property".|
-|bindingName	|String		|""		|✔️|The binding name that is used together with the parameter type.|
-|scriptFormat	|String		|""		|✔️|The script format to use within the binding.|
-|notEmpty		|boolean	|false	|✔️|Option to say whether an input can be empty or not.|
-|isEditable		|boolean	|true	|✔️|Option to say whether an input can be edited by the user or not.|
+|label|String|""|✔️|The label that will be displayed in the Modeler.|
+|type|String||❌|The property type, e.g. String, Hidden, Dropdown.|
+|value|String|""|✔️|The default value selected in the Modeler.|
+|choices|@Choice[]|{}|✔️|An array containing the choices available in a Dropdown menu.|
+|description|String|""|✔️|The description that is shown at the entry in the Modeler.|
+|documentationRef|String|""|✔️|A URL pointing to documentation.|
+|parameterType|String|"input"|✔️|The parameter type of the property, available options are: "input", "output", "property".|
+|bindingName|String|""|✔️|The binding name that is used together with the parameter type.|
+|scriptFormat|String|""|✔️|The script format to use within the binding.|
+|notEmpty|boolean|false|✔️|Option to say whether an input can be empty or not.|
+|isEditable|boolean|true|✔️|Option to say whether an input can be edited by the user or not.|
 
 `@Template`
 The Template annotation can be used to annotate methods. This annotation is absolutely **necessary** because only classes that contain this annotation will be scanned. It represents a Template in the Modeler and contains the corresponding properties which are read from fields of the same class hierarchy annotated with `TemplateProperty`. Since there might be several activities in one Java class which rely on different properties the `Template` annotation can optionally contain a list of multiple `TemplateProperty` annotations that will be included exclusively in the corresponding Template.
 The following matrix gives an overview about the arguments for this annotation:
 | Name | Type | Default value | Optional | Description |
 |-|:-:|:-:|:-:|-|
-|name|String| |❌|The name of the Template shown in the Modeler.|
-|id|String|	|❌|The id of the Template, e.g. "com.example.Template".|
-|appliesTo|String[]| |❌|What this Template should apply to.|
+|name|String||❌|The name of the Template shown in the Modeler.|
+|id|String||❌|The id of the Template, e.g. "com.example.Template".|
+|description|String|""|✔️|The description that is shown at the entry in the Modeler.|
+|documentationRef|String|""|✔️|A URL pointing to documentation.|
+|appliesTo|String[]||❌|What this Template should apply to.|
 |function|String|""|✔️|The name of the function that should be called.|
 |functionNameProperty|String|""|✔️|The binding name of the function that should be called.|
-|templateProperties|@TemplateProperty[]|{}|✔️|An optional additional array of TemplateProperty annotations..|
+|templateProperties|@TemplateProperty[]|{}|✔️|An optional additional array of TemplateProperty annotations.|
 |entriesVisible|boolean|true|✔️|Option to say if the properties should be visible in the Modeler.|
 
 `@Choice`
 This annotation should only be used in the `choices` field of the `TemplateProperty` annotation. It represents one entry of a dropdown menu.
 | Name | Type | Default value | Optional | Description |
 |-|:-:|:-:|:-:|-|
-|name|String| |❌|The name of the dropdown menu entry.
-|value|String| |❌|The value of the dropdown menu entry.
+|name|String||❌|The name of the dropdown menu entry.
+|value|String||❌|The value of the dropdown menu entry.
 
 #### Example 1
 ```java
@@ -88,6 +91,7 @@ This annotation should only be used in the `choices` field of the `TemplatePrope
 ```java
  @Template(name = "Example",
             id = "com.example.Example",
+            description = "Example Template",
             appliesTo = { "bpmn:Task" },
             templateProperties = {
                     @TemplateProperty(label = "Example Additional Property",

--- a/template-generator-core/src/main/java/org/camunda/community/template/generator/Template.java
+++ b/template-generator-core/src/main/java/org/camunda/community/template/generator/Template.java
@@ -30,6 +30,16 @@ public @interface Template {
   public String id();
 
   /**
+   * @return description of the activity
+   */
+  public String description() default "";
+
+  /**
+   * @return documentationRef of the activity
+   */
+  public String documentationRef() default "";
+
+  /**
    * @return types the activity should apply to
    */
   public String[] appliesTo();

--- a/template-generator-core/src/main/java/org/camunda/community/template/generator/TemplateProperty.java
+++ b/template-generator-core/src/main/java/org/camunda/community/template/generator/TemplateProperty.java
@@ -54,6 +54,11 @@ public @interface TemplateProperty {
   public String description() default "";
 
   /**
+   * @return documentationRef of the activity
+   */
+  public String documentationRef() default "";
+
+  /**
    * @return parameter type "input", "output" or "property"
    */
   public String parameterType() default INPUT;

--- a/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/GeneratorParser.java
+++ b/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/GeneratorParser.java
@@ -22,6 +22,8 @@ public class GeneratorParser {
 
   public static final String DESCRIPTION = "description";
 
+  public static final String DOCUMENTATION_REF = "documentationRef";
+
   public static final String INDEX = "index";
 
   public static final String BINDING = "binding";
@@ -155,6 +157,11 @@ public class GeneratorParser {
       property.setDescription(description);
     }
 
+    String documentationRef = String.valueOf(fieldParameters.get(DOCUMENTATION_REF));
+    if (!documentationRef.isBlank()) {
+      property.setDocumentationRef(documentationRef);
+    }
+
     String bindingName = String.valueOf(fieldParameters.get(BINDING_NAME));
     String scriptFormat = String.valueOf(fieldParameters.get(SCRIPT_FORMAT));
     if (!bindingName.isBlank()) {
@@ -197,6 +204,16 @@ public class GeneratorParser {
     String templateID = String.valueOf(methodParameters.get(TEMPLATE_ID));
     if (!templateID.isBlank()) {
       template.setTemplateID(templateID);
+    }
+
+    String description = String.valueOf(methodParameters.get(DESCRIPTION));
+    if (!description.isBlank()) {
+      template.setDescription(description);
+    }
+
+    String documentationRef = String.valueOf(methodParameters.get(DOCUMENTATION_REF));
+    if (!documentationRef.isBlank()) {
+      template.setDocumentationRef(documentationRef);
     }
 
     // Add method specific properties

--- a/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/objectmodel/Property.java
+++ b/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/objectmodel/Property.java
@@ -11,6 +11,8 @@ public class Property {
 
   private String description;
 
+  private String documentationRef;
+
   private String propertyType;
 
   private boolean editable;
@@ -75,6 +77,20 @@ public class Property {
    */
   public void setDescription(String description) {
     this.description = description;
+  }
+
+  /**
+   * @return documentationRef
+   */
+  public String getDocumentationRef() {
+    return documentationRef;
+  }
+
+  /**
+   * @param documentationRef
+   */
+  public void setDocumentationRef(String documentationRef) {
+    this.documentationRef = documentationRef;
   }
 
   /**

--- a/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/objectmodel/Template.java
+++ b/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/objectmodel/Template.java
@@ -12,6 +12,10 @@ public class Template {
 
   private String id;
 
+  private String description;
+
+  private String documentationRef;
+
   private String[] appliesTo;
 
   private boolean entriesVisible;
@@ -58,6 +62,34 @@ public class Template {
    */
   public void setTemplateID(String templateID) {
     this.id = templateID;
+  }
+
+  /**
+   * @return description
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * @param description
+   */
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /**
+   * @return documentationRef
+   */
+  public String getDocumentationRef() {
+    return documentationRef;
+  }
+
+  /**
+   * @param documentationRef
+   */
+  public void setDocumentationRef(String documentationRef) {
+    this.documentationRef = documentationRef;
   }
 
   /**

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/GeneratorTest.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/GeneratorTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class GeneratorTest {
+class GeneratorTest {
 
   List<ClassInfo> classInfosTemplate = new ArrayList<>();
 
@@ -50,7 +50,7 @@ public class GeneratorTest {
   }
 
   @BeforeEach
-  public void testSomething() {
+  void testSomething() {
     for (ClassInfo classInfo : scan("org.camunda.community.template.generator.test.template")) {
       classInfosTemplate.clear();
       classInfosTemplate.add(classInfo);
@@ -82,12 +82,14 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplate() {
+  void testTemplate() {
     List<Template> templates = new ArrayList<>();
 
     Template template = new Template();
     template.setTemplateName("Example");
     template.setTemplateID("com.example.Example");
+    template.setDescription("Example of a Template");
+    template.setDocumentationRef("https://docs.camunda.io");
     template.setAppliesTo(new String[] {"bpmn:Task"});
     template.setEntriesVisible(false);
 
@@ -96,6 +98,7 @@ public class GeneratorTest {
     templatePropertyExample.setType(TemplateProperty.STRING);
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of an additional property");
+    templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
     templatePropertyExample.setBinding(
         new Binding("camunda:inputParameter", "exampleAdditionalProperty"));
     templatePropertyExample.setEditable(false);
@@ -125,7 +128,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplateParameters() {
+  void testTemplateParameters() {
     List<Property> properties = new ArrayList<>();
 
     Choice exampleChoice = new Choice("", "");
@@ -138,6 +141,7 @@ public class GeneratorTest {
     templatePropertyExample.setChoices(new Choice[] {exampleChoice});
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of a property");
+    templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
     templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "null"));
     templatePropertyExample.setEditable(false);
     templatePropertyExample.setConstraint(new Constraint(true));
@@ -151,12 +155,14 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplateMixed() {
+  void testTemplateMixed() {
     List<Template> templates = new ArrayList<>();
 
     Template template = new Template();
     template.setTemplateName("Example");
     template.setTemplateID("com.example.Example");
+    template.setDescription("Example of a Template");
+    template.setDocumentationRef("https://docs.camunda.io");
     template.setAppliesTo(new String[] {"bpmn:Task"});
     template.setEntriesVisible(false);
 
@@ -168,6 +174,7 @@ public class GeneratorTest {
     templatePropertyExample.setType(TemplateProperty.STRING);
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of a property");
+    templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
     templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "null"));
     templatePropertyExample.setEditable(false);
     templatePropertyExample.setConstraint(constraint);
@@ -177,6 +184,7 @@ public class GeneratorTest {
     templateAdditionalPropertyExample.setType(TemplateProperty.STRING);
     templateAdditionalPropertyExample.setValue("example");
     templateAdditionalPropertyExample.setDescription("Example of an additional property");
+    templateAdditionalPropertyExample.setDocumentationRef("https://docs.camunda.io");
     templateAdditionalPropertyExample.setBinding(
         new Binding("camunda:inputParameter", "exampleAdditionalProperty"));
     templateAdditionalPropertyExample.setEditable(false);
@@ -208,18 +216,22 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplateMultiple() {
+  void testTemplateMultiple() {
     List<Template> templates = new ArrayList<>();
 
     Template templateOne = new Template();
     templateOne.setTemplateName("ExampleOne");
     templateOne.setTemplateID("com.example.ExampleOne");
+    templateOne.setDescription("Example of a Template");
+    templateOne.setDocumentationRef("https://docs.camunda.io");
     templateOne.setAppliesTo(new String[] {"bpmn:Task"});
     templateOne.setEntriesVisible(false);
 
     Template templateTwo = new Template();
     templateTwo.setTemplateName("ExampleTwo");
     templateTwo.setTemplateID("com.example.ExampleTwo");
+    templateTwo.setDescription("Example of a Template");
+    templateTwo.setDocumentationRef("https://docs.camunda.io");
     templateTwo.setAppliesTo(new String[] {"bpmn:Task"});
     templateTwo.setEntriesVisible(false);
 
@@ -228,6 +240,7 @@ public class GeneratorTest {
     templatePropertyExample.setType(TemplateProperty.STRING);
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of a property");
+    templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
     templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "null"));
     templatePropertyExample.setEditable(false);
     templatePropertyExample.setConstraint(new Constraint(true));
@@ -237,6 +250,7 @@ public class GeneratorTest {
     templateAdditionalPropertyExampleOne.setType(TemplateProperty.STRING);
     templateAdditionalPropertyExampleOne.setValue("exampleOne");
     templateAdditionalPropertyExampleOne.setDescription("Example of an additional property");
+    templateAdditionalPropertyExampleOne.setDocumentationRef("https://docs.camunda.io");
     templateAdditionalPropertyExampleOne.setBinding(
         new Binding("camunda:inputParameter", "exampleAdditionalPropertyOne"));
     templateAdditionalPropertyExampleOne.setEditable(false);
@@ -251,6 +265,7 @@ public class GeneratorTest {
     templateAdditionalPropertyExampleTwo.setType(TemplateProperty.STRING);
     templateAdditionalPropertyExampleTwo.setValue("exampleTwo");
     templateAdditionalPropertyExampleTwo.setDescription("Example of an additional property");
+    templateAdditionalPropertyExampleTwo.setDocumentationRef("https://docs.camunda.io");
     templateAdditionalPropertyExampleTwo.setBinding(templateAdditionalPropertyTwoBinding);
     templateAdditionalPropertyExampleTwo.setEditable(true);
     templateAdditionalPropertyExampleTwo.setConstraint(new Constraint(false));
@@ -293,12 +308,14 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplateExternalTask() {
+  void testTemplateExternalTask() {
     List<Template> templates = new ArrayList<>();
 
     Template template = new Template();
     template.setTemplateName("External Task Example");
     template.setTemplateID("com.example.ExternalTaskExample");
+    template.setDescription("Example of a Template");
+    template.setDocumentationRef("https://docs.camunda.io");
     template.setAppliesTo(new String[] {"bpmn:Task"});
     template.setEntriesVisible(false);
 
@@ -307,6 +324,7 @@ public class GeneratorTest {
     templatePropertyExample.setType(TemplateProperty.STRING);
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of an additional property");
+    templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
     templatePropertyExample.setBinding(
         new Binding("camunda:inputParameter", "exampleAdditionalProperty"));
     templatePropertyExample.setEditable(false);
@@ -354,7 +372,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplateJsonOutput() throws MojoExecutionException, IOException {
+  void testTemplateJsonOutput() throws MojoExecutionException, IOException {
     new Generator()
         .generate(
             "0.12.0",
@@ -374,7 +392,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplateMixedJsonOutput() throws MojoExecutionException, IOException {
+  void testTemplateMixedJsonOutput() throws MojoExecutionException, IOException {
     new Generator()
         .generate(
             "0.12.0",
@@ -395,7 +413,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplateParametersJsonOutput() throws MojoExecutionException, IOException {
+  void testTemplateParametersJsonOutput() throws MojoExecutionException, IOException {
     new Generator()
         .generate(
             "0.12.0",
@@ -416,7 +434,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplateMultipleJsonOutput() throws MojoExecutionException, IOException {
+  void testTemplateMultipleJsonOutput() throws MojoExecutionException, IOException {
     new Generator()
         .generate(
             "0.12.0",
@@ -437,7 +455,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testTemplateExternalTaskJsonOutput() throws MojoExecutionException, IOException {
+  void testTemplateExternalTaskJsonOutput() throws MojoExecutionException, IOException {
     new Generator()
         .generate(
             "0.12.0",
@@ -459,7 +477,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testMalformedJSON() throws Exception {
+  void testMalformedJSON() throws Exception {
     JsonSchema schema =
         new Generator().downloadSchema(SCHEMA_BASE_URL + "@0.12.0" + "/resources/schema.json");
 
@@ -480,7 +498,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testMalformedSchemaURL() {
+  void testMalformedSchemaURL() {
     Exception exception =
         assertThrows(
             MojoExecutionException.class,
@@ -496,7 +514,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testBindingScriptFormat() {
+  void testBindingScriptFormat() {
     Binding expectedBinding = new Binding();
     expectedBinding.setType(INPUT_PARAMETER);
     expectedBinding.setName("exampleBinding");
@@ -510,7 +528,7 @@ public class GeneratorTest {
   }
 
   @Test
-  public void testDuplicateTemplateID() {
+  void testDuplicateTemplateID() {
     Exception exception =
         assertThrows(
             MojoExecutionException.class,

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/duplicatetemplateid/TestDuplicateTemplateID.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/duplicatetemplateid/TestDuplicateTemplateID.java
@@ -11,6 +11,8 @@ public class TestDuplicateTemplateID extends TestTemplate {
   @Template(
       name = "Example", //
       id = "com.example.Example", //
+      description = "Example of a Template", //
+      documentationRef = "https://docs.camunda.io", //
       appliesTo = {"bpmn:Task"}, //
       function = "exampleFunction", //
       functionNameProperty = "exampleNameProperty", //
@@ -19,6 +21,7 @@ public class TestDuplicateTemplateID extends TestTemplate {
         @TemplateProperty(
             label = "Example Additional Property", //
             description = "Example of an additional property", //
+            documentationRef = "https://docs.camunda.io", //
             parameterType = TemplateProperty.INPUT, //
             type = TemplateProperty.STRING, //
             value = "example", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/template/TestTemplate.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/template/TestTemplate.java
@@ -10,6 +10,8 @@ public class TestTemplate {
   @Template(
       name = "Example", //
       id = "com.example.Example", //
+      description = "Example of a Template", //
+      documentationRef = "https://docs.camunda.io", //
       appliesTo = {"bpmn:Task"}, //
       function = "exampleFunction", //
       functionNameProperty = "exampleNameProperty", //
@@ -18,6 +20,7 @@ public class TestTemplate {
         @TemplateProperty(
             label = "Example Additional Property", //
             description = "Example of an additional property", //
+            documentationRef = "https://docs.camunda.io", //
             parameterType = TemplateProperty.INPUT, //
             type = TemplateProperty.STRING, //
             value = "example", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templateexternaltask/TestTemplateExternalTask.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templateexternaltask/TestTemplateExternalTask.java
@@ -10,12 +10,15 @@ public class TestTemplateExternalTask {
   @Template(
       name = "External Task Example", //
       id = "com.example.ExternalTaskExample", //
+      description = "Example of a Template", //
+      documentationRef = "https://docs.camunda.io", //
       appliesTo = {"bpmn:Task"}, //
       entriesVisible = false, //
       templateProperties = {
         @TemplateProperty(
             label = "External Task Example Additional Property", //
             description = "Example of an additional property", //
+            documentationRef = "https://docs.camunda.io", //
             parameterType = TemplateProperty.INPUT, //
             type = TemplateProperty.STRING, //
             value = "example", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatemixed/TestTemplateMixed.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatemixed/TestTemplateMixed.java
@@ -8,6 +8,7 @@ public class TestTemplateMixed {
   @TemplateProperty(
       label = "Example Property", //
       description = "Example of a property", //
+      documentationRef = "https://docs.camunda.io", //
       parameterType = TemplateProperty.INPUT, //
       type = TemplateProperty.STRING, //
       value = "example", //
@@ -18,6 +19,8 @@ public class TestTemplateMixed {
   @Template(
       name = "Example", //
       id = "com.example.Example", //
+      description = "Example of a Template", //
+      documentationRef = "https://docs.camunda.io", //
       appliesTo = {"bpmn:Task"}, //
       function = "exampleFunction", //
       functionNameProperty = "exampleNameProperty", //
@@ -26,6 +29,7 @@ public class TestTemplateMixed {
         @TemplateProperty(
             label = "Example Additional Property", //
             description = "Example of an additional property", //
+            documentationRef = "https://docs.camunda.io", //
             parameterType = TemplateProperty.INPUT, //
             type = TemplateProperty.STRING, //
             value = "example", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatemultiple/TestTemplateMultiple.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatemultiple/TestTemplateMultiple.java
@@ -8,6 +8,7 @@ public class TestTemplateMultiple {
   @TemplateProperty(
       label = "Example Property", //
       description = "Example of a property", //
+      documentationRef = "https://docs.camunda.io", //
       parameterType = TemplateProperty.INPUT, //
       type = TemplateProperty.STRING, //
       value = "example", //
@@ -18,6 +19,8 @@ public class TestTemplateMultiple {
   @Template(
       name = "ExampleOne", //
       id = "com.example.ExampleOne", //
+      description = "Example of a Template", //
+      documentationRef = "https://docs.camunda.io", //
       appliesTo = {"bpmn:Task"}, //
       function = "exampleFunctionOne", //
       functionNameProperty = "exampleNamePropertyOne", //
@@ -26,6 +29,7 @@ public class TestTemplateMultiple {
         @TemplateProperty(
             label = "Example Additional Property One", //
             description = "Example of an additional property", //
+            documentationRef = "https://docs.camunda.io", //
             parameterType = TemplateProperty.INPUT, //
             type = TemplateProperty.STRING, //
             value = "exampleOne", //
@@ -38,6 +42,8 @@ public class TestTemplateMultiple {
   @Template(
       name = "ExampleTwo", //
       id = "com.example.ExampleTwo", //
+      description = "Example of a Template", //
+      documentationRef = "https://docs.camunda.io", //
       appliesTo = {"bpmn:Task"}, //
       function = "exampleFunctionTwo", //
       functionNameProperty = "exampleNamePropertyTwo", //
@@ -46,6 +52,7 @@ public class TestTemplateMultiple {
         @TemplateProperty(
             label = "Example Additional Property Two", //
             description = "Example of an additional property", //
+            documentationRef = "https://docs.camunda.io", //
             parameterType = TemplateProperty.OUTPUT, //
             type = TemplateProperty.STRING, //
             value = "exampleTwo", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templateparameters/TestTemplateParameters.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templateparameters/TestTemplateParameters.java
@@ -9,6 +9,7 @@ public class TestTemplateParameters {
   @TemplateProperty(
       label = "Example Property", //
       description = "Example of a property", //
+      documentationRef = "https://docs.camunda.io", //
       parameterType = TemplateProperty.INPUT, //
       type = TemplateProperty.DROPDOWN, //
       choices = {@Choice(name = "exampleChoice", value = "exampleChoiceValue")}, //
@@ -20,6 +21,8 @@ public class TestTemplateParameters {
   @Template(
       name = "Example", //
       id = "com.example.Example", //
+      description = "Example of a Template", //
+      documentationRef = "https://docs.camunda.io", //
       appliesTo = {"bpmn:Task"}, //
       function = "exampleFunction", //
       functionNameProperty = "exampleNameProperty", //

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestMalformedJSON.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestMalformedJSON.json
@@ -3,6 +3,8 @@
     "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.12.0/resources/schema.json",
     "name": "Example",
     "id": "com.example.Example",
+    "description": "Example of a Template",
+    "documentationRef": "https://docs.camunda.io",
     "appliesTo": [
       "bpmn:Task"
     ],
@@ -13,6 +15,7 @@
         "type": "String",
         "value": "example",
         "description": "Example of an additional property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": false,
         "constraints": {
           "notEmpty": true

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateExternalTaskTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateExternalTaskTemplates.json
@@ -3,6 +3,8 @@
     "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.12.0/resources/schema.json",
     "name": "External Task Example",
     "id": "com.example.ExternalTaskExample",
+    "description": "Example of a Template",
+    "documentationRef": "https://docs.camunda.io",
     "appliesTo": [
       "bpmn:Task"
     ],
@@ -13,6 +15,7 @@
         "type": "String",
         "value": "example",
         "description": "Example of an additional property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": false,
         "constraints": {
           "notEmpty": true

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMixedTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMixedTemplates.json
@@ -3,6 +3,8 @@
     "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.12.0/resources/schema.json",
     "name": "Example",
     "id": "com.example.Example",
+    "description": "Example of a Template",
+    "documentationRef": "https://docs.camunda.io",
     "appliesTo": [
       "bpmn:Task"
     ],
@@ -13,6 +15,7 @@
         "type": "String",
         "value": "example",
         "description": "Example of an additional property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": false,
         "constraints": {
           "notEmpty": true
@@ -36,6 +39,7 @@
         "type": "String",
         "value": "example",
         "description": "Example of a property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": false,
         "constraints": {
           "notEmpty": true

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMultipleTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMultipleTemplates.json
@@ -3,6 +3,8 @@
     "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.12.0/resources/schema.json",
     "name": "ExampleOne",
     "id": "com.example.ExampleOne",
+    "description": "Example of a Template",
+    "documentationRef": "https://docs.camunda.io",
     "appliesTo": [
       "bpmn:Task"
     ],
@@ -13,6 +15,7 @@
         "type": "String",
         "value": "exampleOne",
         "description": "Example of an additional property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": false,
         "constraints": {
           "notEmpty": true
@@ -36,6 +39,7 @@
         "type": "String",
         "value": "example",
         "description": "Example of a property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": false,
         "constraints": {
           "notEmpty": true
@@ -60,6 +64,8 @@
     "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.12.0/resources/schema.json",
     "name": "ExampleTwo",
     "id": "com.example.ExampleTwo",
+    "description": "Example of a Template",
+    "documentationRef": "https://docs.camunda.io",
     "appliesTo": [
       "bpmn:Task"
     ],
@@ -70,6 +76,7 @@
         "type": "String",
         "value": "exampleTwo",
         "description": "Example of an additional property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": true,
         "constraints": {
           "notEmpty": false
@@ -93,6 +100,7 @@
         "type": "String",
         "value": "example",
         "description": "Example of a property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": false,
         "constraints": {
           "notEmpty": true

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateParametersTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateParametersTemplates.json
@@ -3,6 +3,8 @@
     "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.12.0/resources/schema.json",
     "name": "Example",
     "id": "com.example.Example",
+    "description": "Example of a Template",
+    "documentationRef": "https://docs.camunda.io",
     "appliesTo": [
       "bpmn:Task"
     ],
@@ -22,6 +24,7 @@
         "type": "Dropdown",
         "value": "example",
         "description": "Example of a property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": false,
         "choices": [
           {

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateTemplates.json
@@ -3,6 +3,8 @@
     "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.12.0/resources/schema.json",
     "name": "Example",
     "id": "com.example.Example",
+    "description": "Example of a Template",
+    "documentationRef": "https://docs.camunda.io",
     "appliesTo": [
       "bpmn:Task"
     ],
@@ -13,6 +15,7 @@
         "type": "String",
         "value": "example",
         "description": "Example of an additional property",
+        "documentationRef": "https://docs.camunda.io",
         "editable": false,
         "constraints": {
           "notEmpty": true


### PR DESCRIPTION
Fixes #70 

This PR adds support for `documentationRef` on `Template` and `TemplateProperty`
While at it I also added support for `description` field on `Template`.

Tests have been adapted to validate the functionality.

IMHO: There are plenty of other fields defined in the `schema.json` that are currently not covered by the annotations / plugin. It may be worth to make it feature complete in the long run.