### PR TITLE
fix(ci): correct deployment workflow for Sonatype Central

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -16,50 +16,38 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - name: Cache
-        uses: actions/cache@v4.2.3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+      - name: Checks out code
+        uses: actions/checkout@v4
+
       - name: Set up Java environment
         uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: temurin
+          cache: maven
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
-      - name: Build
-        id: build
-        run: mvn -B -U -Dsurefire.rerunFailingTestsCount=5 clean install
-      - name: Archive Test Results on Failure
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: test-results
-          path: target/surefire-reports/
-          retention-days: 7
-      - name: Publish Unit Test Results
-        id: publish
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: failure()
-        with:
-          files: target/surefire-reports/*.xml
+
       - name: Deploy SNAPSHOT / Release
-        uses: camunda-community-hub/community-action-maven-release@v2.0.1
+        uses: camunda-community-hub/community-action-maven-release@v2
+        id: release
         with:
           release-version: ${{ github.event.release.tag_name }}
           nexus-usr: ${{ secrets.NEXUS_USR }}
           nexus-psw: ${{ secrets.NEXUS_PSW }}
-          maven-usr: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_OSS_USR }}
-          maven-psw: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_OSS_PSW }}
-          maven-url: oss.sonatype.org
+          sonatype-central-portal-usr: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_CP_USR }}
+          sonatype-central-portal-psw: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_CP_PSW }}
           maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
           maven-auto-release-after-close: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        id: release
+
+      - name: Archive Test Results on Failure
+        if: failure() && steps.release.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/surefire-reports/'
+          retention-days: 7
 
       - if: github.event.release
         name: Attach artifacts to GitHub Release (Release only)


### PR DESCRIPTION
The CI workflow failed with a 401 Unauthorized error due to Sonatype's migration to a new token-based Central Portal.

This commit updates the GitHub Actions workflow to align with the new requirements and best practices of the camunda-community-hub/community-action-maven-release action.

Changes include:
- Replacing deprecated 'maven-usr' and 'maven-psw' inputs with the correct 'sonatype-central-portal-usr' and '-psw' credentials.
- Removing the redundant 'mvn install' build step, as the release action handles the entire lifecycle.
- Simplifying the setup by using the built-in Maven caching from actions/setup-java.
- Re-instating the step to archive Surefire test reports on failure for better debugging.