### PR TITLE
feat: Add pattern validation for properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The following matrix gives an overview about the arguments for this annotation:
 |bindingName|String|""|✔️|The binding name that is used together with the parameter type.|
 |scriptFormat|String|""|✔️|The script format to use within the binding.|
 |notEmpty|boolean|false|✔️|Option to say whether an input can be empty or not.|
+|pattern|String|""|✔️|A regex pattern to validate the input against.|
+|patternErrorMessage|String|""|✔️|A custom error message to display if the pattern validation fails.|
 |isEditable|boolean|true|✔️|Option to say whether an input can be edited by the user or not.|
 
 `@Template`

--- a/template-generator-core/src/main/java/org/camunda/community/template/generator/TemplateProperty.java
+++ b/template-generator-core/src/main/java/org/camunda/community/template/generator/TemplateProperty.java
@@ -79,6 +79,16 @@ public @interface TemplateProperty {
   public boolean notEmpty() default false;
 
   /**
+   * @return pattern for the property
+   */
+  public String pattern() default "";
+
+  /**
+   * @return error message for the pattern
+   */
+  public String patternErrorMessage() default "";
+
+  /**
    * @return whether the property should be editable by the user or not
    */
   public boolean isEditable() default true;

--- a/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/objectmodel/Constraint.java
+++ b/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/objectmodel/Constraint.java
@@ -3,27 +3,38 @@ package org.camunda.community.template.generator.objectmodel;
 /** A constrained that is contained by a property */
 public class Constraint {
 
-  private boolean notEmpty;
+  private Boolean notEmpty;
+  private Pattern pattern;
+
+  public Constraint() {
+    super();
+  }
 
   /**
    * @return notEmpty
    */
-  public boolean isNotEmpty() {
+  public Boolean isNotEmpty() {
     return notEmpty;
   }
 
   /**
    * @param notEmpty
    */
-  public void setNotEmpty(boolean notEmpty) {
+  public void setNotEmpty(Boolean notEmpty) {
     this.notEmpty = notEmpty;
   }
 
   /**
-   * @param notEmpty
+   * @return pattern
    */
-  public Constraint(boolean notEmpty) {
-    super();
-    this.notEmpty = notEmpty;
+  public Pattern getPattern() {
+    return pattern;
+  }
+
+  /**
+   * @param pattern
+   */
+  public void setPattern(Pattern pattern) {
+    this.pattern = pattern;
   }
 }

--- a/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/objectmodel/Pattern.java
+++ b/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/objectmodel/Pattern.java
@@ -1,0 +1,31 @@
+package org.camunda.community.template.generator.objectmodel;
+
+/** Pattern for a constraint */
+public class Pattern {
+
+  private String value;
+  private String message;
+
+  public Pattern() {}
+
+  public Pattern(String value, String message) {
+    this.value = value;
+    this.message = message;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/GeneratorTest.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/GeneratorTest.java
@@ -42,6 +42,8 @@ class GeneratorTest {
 
   List<ClassInfo> classInfosTemplateExternalTask = new ArrayList<>();
 
+  List<ClassInfo> classInfosTemplatePattern = new ArrayList<>();
+
   ClassInfoList scan(String scanPackages) {
     ScanResult scanResult = new ClassGraph().acceptPackages(scanPackages).enableAllInfo().scan();
 
@@ -79,6 +81,12 @@ class GeneratorTest {
       classInfosTemplateExternalTask.clear();
       classInfosTemplateExternalTask.add(classInfo);
     }
+
+    for (ClassInfo classInfo :
+        scan("org.camunda.community.template.generator.test.templatepattern")) {
+      classInfosTemplatePattern.clear();
+      classInfosTemplatePattern.add(classInfo);
+    }
   }
 
   @Test
@@ -102,19 +110,23 @@ class GeneratorTest {
     templatePropertyExample.setBinding(
         new Binding("camunda:inputParameter", "exampleAdditionalProperty"));
     templatePropertyExample.setEditable(false);
-    templatePropertyExample.setConstraint(new Constraint(true));
+    Constraint constraint = new Constraint();
+    constraint.setNotEmpty(true);
+    templatePropertyExample.setConstraint(constraint);
 
     Property templateProperty = new Property();
     templateProperty.setType(TemplateProperty.HIDDEN);
     templateProperty.setValue(
         "org.camunda.community.template.generator.test.template.TestTemplate");
     templateProperty.setBinding(new Binding(TemplateProperty.PROPERTY, "camunda:class"));
+    templateProperty.setEditable(false);
 
     Property templateFunctionProperty = new Property();
     templateFunctionProperty.setType(TemplateProperty.HIDDEN);
     templateFunctionProperty.setValue("exampleFunction");
     templateFunctionProperty.setBinding(
         new Binding("camunda:inputParameter", "exampleNameProperty"));
+    templateFunctionProperty.setEditable(false);
 
     template.addTemplateProperty(templatePropertyExample);
     template.addTemplateProperty(templateFunctionProperty);
@@ -142,9 +154,11 @@ class GeneratorTest {
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of a property");
     templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
-    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "null"));
+    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "test"));
     templatePropertyExample.setEditable(false);
-    templatePropertyExample.setConstraint(new Constraint(true));
+    Constraint constraint = new Constraint();
+    constraint.setNotEmpty(true);
+    templatePropertyExample.setConstraint(constraint);
 
     properties.add(templatePropertyExample);
 
@@ -166,7 +180,7 @@ class GeneratorTest {
     template.setAppliesTo(new String[] {"bpmn:Task"});
     template.setEntriesVisible(false);
 
-    Constraint constraint = new Constraint(false);
+    Constraint constraint = new Constraint();
     constraint.setNotEmpty(true);
 
     Property templatePropertyExample = new Property();
@@ -175,7 +189,7 @@ class GeneratorTest {
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of a property");
     templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
-    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "null"));
+    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "test"));
     templatePropertyExample.setEditable(false);
     templatePropertyExample.setConstraint(constraint);
 
@@ -188,19 +202,23 @@ class GeneratorTest {
     templateAdditionalPropertyExample.setBinding(
         new Binding("camunda:inputParameter", "exampleAdditionalProperty"));
     templateAdditionalPropertyExample.setEditable(false);
-    templateAdditionalPropertyExample.setConstraint(new Constraint(true));
+    Constraint constraint2 = new Constraint();
+    constraint2.setNotEmpty(true);
+    templateAdditionalPropertyExample.setConstraint(constraint2);
 
     Property templateProperty = new Property();
     templateProperty.setType(TemplateProperty.HIDDEN);
     templateProperty.setValue(
         "org.camunda.community.template.generator.test.templatemixed.TestTemplateMixed");
     templateProperty.setBinding(new Binding(TemplateProperty.PROPERTY, "camunda:class"));
+    templateProperty.setEditable(false);
 
     Property templateFunctionProperty = new Property();
     templateFunctionProperty.setType(TemplateProperty.HIDDEN);
     templateFunctionProperty.setValue("exampleFunction");
     templateFunctionProperty.setBinding(
         new Binding("camunda:inputParameter", "exampleNameProperty"));
+    templateFunctionProperty.setEditable(false);
 
     template.addTemplateProperty(templateAdditionalPropertyExample);
     template.addTemplateProperty(templateFunctionProperty);
@@ -241,9 +259,11 @@ class GeneratorTest {
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of a property");
     templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
-    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "null"));
+    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "test"));
     templatePropertyExample.setEditable(false);
-    templatePropertyExample.setConstraint(new Constraint(true));
+    Constraint constraint1 = new Constraint();
+    constraint1.setNotEmpty(true);
+    templatePropertyExample.setConstraint(constraint1);
 
     Property templateAdditionalPropertyExampleOne = new Property();
     templateAdditionalPropertyExampleOne.setLabel("Example Additional Property One");
@@ -254,7 +274,9 @@ class GeneratorTest {
     templateAdditionalPropertyExampleOne.setBinding(
         new Binding("camunda:inputParameter", "exampleAdditionalPropertyOne"));
     templateAdditionalPropertyExampleOne.setEditable(false);
-    templateAdditionalPropertyExampleOne.setConstraint(new Constraint(true));
+    Constraint constraint2 = new Constraint();
+    constraint2.setNotEmpty(true);
+    templateAdditionalPropertyExampleOne.setConstraint(constraint2);
 
     Binding templateAdditionalPropertyTwoBinding = new Binding();
     templateAdditionalPropertyTwoBinding.setType("camunda:outputParameter");
@@ -268,25 +290,27 @@ class GeneratorTest {
     templateAdditionalPropertyExampleTwo.setDocumentationRef("https://docs.camunda.io");
     templateAdditionalPropertyExampleTwo.setBinding(templateAdditionalPropertyTwoBinding);
     templateAdditionalPropertyExampleTwo.setEditable(true);
-    templateAdditionalPropertyExampleTwo.setConstraint(new Constraint(false));
 
     Property templateProperty = new Property();
     templateProperty.setType(TemplateProperty.HIDDEN);
     templateProperty.setValue(
         "org.camunda.community.template.generator.test.templatemultiple.TestTemplateMultiple");
     templateProperty.setBinding(new Binding(TemplateProperty.PROPERTY, "camunda:class"));
+    templateProperty.setEditable(false);
 
     Property templateFunctionPropertyOne = new Property();
     templateFunctionPropertyOne.setType(TemplateProperty.HIDDEN);
     templateFunctionPropertyOne.setValue("exampleFunctionOne");
     templateFunctionPropertyOne.setBinding(
         new Binding("camunda:inputParameter", "exampleNamePropertyOne"));
+    templateFunctionPropertyOne.setEditable(false);
 
     Property templateFunctionPropertyTwo = new Property();
     templateFunctionPropertyTwo.setType(TemplateProperty.HIDDEN);
     templateFunctionPropertyTwo.setValue("exampleFunctionTwo");
     templateFunctionPropertyTwo.setBinding(
         new Binding("camunda:inputParameter", "exampleNamePropertyTwo"));
+    templateFunctionPropertyTwo.setEditable(false);
 
     templateOne.addTemplateProperty(templateAdditionalPropertyExampleOne);
     templateOne.addTemplateProperty(templateFunctionPropertyOne);
@@ -328,27 +352,29 @@ class GeneratorTest {
     templatePropertyExample.setBinding(
         new Binding("camunda:inputParameter", "exampleAdditionalProperty"));
     templatePropertyExample.setEditable(false);
-    templatePropertyExample.setConstraint(new Constraint(true));
+    Constraint constraint1 = new Constraint();
+    constraint1.setNotEmpty(true);
+    templatePropertyExample.setConstraint(constraint1);
 
     Property externalTaskFunctionProperty = new Property();
     externalTaskFunctionProperty.setType(TemplateProperty.HIDDEN);
     externalTaskFunctionProperty.setValue("external");
     externalTaskFunctionProperty.setEditable(false);
     externalTaskFunctionProperty.setBinding(new Binding(TemplateProperty.PROPERTY, "camunda:type"));
-    externalTaskFunctionProperty.setConstraint(new Constraint(false));
 
     Property externalTaskTopic = new Property();
     externalTaskTopic.setLabel("External Topic");
     externalTaskTopic.setType(TemplateProperty.STRING);
     externalTaskTopic.setEditable(true);
-    externalTaskTopic.setConstraint(new Constraint(true));
+    Constraint constraint2 = new Constraint();
+    constraint2.setNotEmpty(true);
+    externalTaskTopic.setConstraint(constraint2);
     externalTaskTopic.setBinding(new Binding(TemplateProperty.PROPERTY, "camunda:topic"));
 
     Property externalTaskPriority = new Property();
     externalTaskPriority.setLabel("External Task Priority");
     externalTaskPriority.setType(TemplateProperty.STRING);
     externalTaskPriority.setEditable(true);
-    externalTaskPriority.setConstraint(new Constraint(false));
     externalTaskPriority.setBinding(new Binding(TemplateProperty.PROPERTY, "camunda:taskPriority"));
 
     Property templateProperty = new Property();
@@ -356,6 +382,7 @@ class GeneratorTest {
     templateProperty.setValue(
         "org.camunda.community.template.generator.test.templateexternaltask.TestTemplateExternalTask");
     templateProperty.setBinding(new Binding(TemplateProperty.PROPERTY, "camunda:class"));
+    templateProperty.setEditable(false);
 
     template.addTemplateProperty(templatePropertyExample);
     template.addTemplateProperty(externalTaskFunctionProperty);
@@ -367,6 +394,58 @@ class GeneratorTest {
 
     List<Template> resultTemplates =
         GeneratorParser.processTemplates(classInfosTemplateExternalTask.get(0));
+
+    assertThat(resultTemplates).usingRecursiveComparison().isEqualTo(templates);
+  }
+
+  @Test
+  void testTemplatePattern() {
+    List<Template> templates = new ArrayList<>();
+
+    Template template = new Template();
+    template.setTemplateName("Pattern Example");
+    template.setTemplateID("com.example.PatternExample");
+    template.setAppliesTo(new String[] {"bpmn:ServiceTask"});
+    template.setEntriesVisible(true);
+
+    Property prop1 = new Property();
+    prop1.setLabel("Property with pattern");
+    prop1.setType(TemplateProperty.STRING);
+    prop1.setEditable(true);
+    prop1.setBinding(new Binding(INPUT_PARAMETER, "propertyWithPattern"));
+    Constraint constraint1 = new Constraint();
+    constraint1.setPattern(
+        new org.camunda.community.template.generator.objectmodel.Pattern(
+            "^[a-zA-Z0-9]+$", "Only alphanumeric characters are allowed."));
+    prop1.setConstraint(constraint1);
+
+    Property prop2 = new Property();
+    prop2.setLabel("Property with pattern and notEmpty");
+    prop2.setType(TemplateProperty.STRING);
+    prop2.setEditable(true);
+    prop2.setBinding(new Binding(INPUT_PARAMETER, "propertyWithPatternAndNotEmpty"));
+    Constraint constraint2 = new Constraint();
+    constraint2.setNotEmpty(true);
+    constraint2.setPattern(
+        new org.camunda.community.template.generator.objectmodel.Pattern(
+            "^\\d{4}$", "Must be a 4-digit number."));
+    prop2.setConstraint(constraint2);
+
+    Property implProperty = new Property();
+    implProperty.setType(TemplateProperty.HIDDEN);
+    implProperty.setValue(
+        "org.camunda.community.template.generator.test.templatepattern.TestTemplatePattern");
+    implProperty.setBinding(new Binding(TemplateProperty.PROPERTY, "camunda:class"));
+    implProperty.setEditable(false);
+
+    template.addTemplateProperty(prop1);
+    template.addTemplateProperty(prop2);
+    template.addTemplateProperty(implProperty);
+
+    templates.add(template);
+
+    List<Template> resultTemplates =
+        GeneratorParser.processTemplates(classInfosTemplatePattern.get(0));
 
     assertThat(resultTemplates).usingRecursiveComparison().isEqualTo(templates);
   }
@@ -471,6 +550,27 @@ class GeneratorTest {
         FileUtils.fileRead(
                 new File(
                     "target/test-files/resources/actual/TestTemplateExternalTaskTemplates.json"))
+            .replace("\n", "")
+            .replace("\r", ""),
+        "Files are not equal!");
+  }
+
+  @Test
+  void testTemplatePatternJsonOutput() throws MojoExecutionException, IOException {
+    new Generator()
+        .generate(
+            "0.12.0",
+            "org.camunda.community.template.generator.test.templatepattern",
+            "target/test-files/resources/actual",
+            false);
+
+    assertEquals(
+        FileUtils.fileRead(
+                new File("src/test/resources/test-expected/TestTemplatePatternTemplates.json"))
+            .replace("\n", "")
+            .replace("\r", ""),
+        FileUtils.fileRead(
+                new File("target/test-files/resources/actual/TestTemplatePatternTemplates.json"))
             .replace("\n", "")
             .replace("\r", ""),
         "Files are not equal!");

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatepattern/TestTemplatePattern.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatepattern/TestTemplatePattern.java
@@ -1,0 +1,28 @@
+package org.camunda.community.template.generator.test.templatepattern;
+
+import org.camunda.community.template.generator.Template;
+import org.camunda.community.template.generator.TemplateProperty;
+
+public class TestTemplatePattern {
+
+  @TemplateProperty(
+      label = "Property with pattern",
+      type = TemplateProperty.STRING,
+      pattern = "^[a-zA-Z0-9]+$",
+      patternErrorMessage = "Only alphanumeric characters are allowed.")
+  String propertyWithPattern = "prop1";
+
+  @TemplateProperty(
+      label = "Property with pattern and notEmpty",
+      type = TemplateProperty.STRING,
+      notEmpty = true,
+      pattern = "^\\d{4}$",
+      patternErrorMessage = "Must be a 4-digit number.")
+  String propertyWithPatternAndNotEmpty = "prop2";
+
+  @Template(
+      name = "Pattern Example",
+      id = "com.example.PatternExample",
+      appliesTo = {"bpmn:ServiceTask"})
+  public void testMethod() {}
+}

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateExternalTaskTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateExternalTaskTemplates.json
@@ -29,9 +29,6 @@
         "type": "Hidden",
         "value": "external",
         "editable": false,
-        "constraints": {
-          "notEmpty": false
-        },
         "binding": {
           "type": "property",
           "name": "camunda:type"
@@ -53,9 +50,6 @@
         "label": "External Task Priority",
         "type": "String",
         "editable": true,
-        "constraints": {
-          "notEmpty": false
-        },
         "binding": {
           "type": "property",
           "name": "camunda:taskPriority"

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMixedTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMixedTemplates.json
@@ -46,7 +46,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "null"
+          "name": "test"
         }
       },
       {

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMultipleTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMultipleTemplates.json
@@ -46,7 +46,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "null"
+          "name": "test"
         }
       },
       {
@@ -78,9 +78,6 @@
         "description": "Example of an additional property",
         "documentationRef": "https://docs.camunda.io",
         "editable": true,
-        "constraints": {
-          "notEmpty": false
-        },
         "binding": {
           "type": "camunda:outputParameter",
           "source": "${exampleAdditionalPropertyTwo}"
@@ -107,7 +104,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "null"
+          "name": "test"
         }
       },
       {

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateParametersTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateParametersTemplates.json
@@ -37,7 +37,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "null"
+          "name": "test"
         }
       },
       {

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplatePatternTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplatePatternTemplates.json
@@ -1,0 +1,53 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.12.0/resources/schema.json",
+    "name": "Pattern Example",
+    "id": "com.example.PatternExample",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "entriesVisible": true,
+    "properties": [
+      {
+        "label": "Property with pattern",
+        "type": "String",
+        "editable": true,
+        "constraints": {
+          "pattern": {
+            "value": "^[a-zA-Z0-9]+$",
+            "message": "Only alphanumeric characters are allowed."
+          }
+        },
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "propertyWithPattern"
+        }
+      },
+      {
+        "label": "Property with pattern and notEmpty",
+        "type": "String",
+        "editable": true,
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^\\d{4}$",
+            "message": "Must be a 4-digit number."
+          }
+        },
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "propertyWithPatternAndNotEmpty"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "org.camunda.community.template.generator.test.templatepattern.TestTemplatePattern",
+        "editable": false,
+        "binding": {
+          "type": "property",
+          "name": "camunda:class"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Implements property validation using regex patterns and custom error messages as suggested in the element template JSON schema.

- Adds 'pattern' and 'patternErrorMessage' to @TemplateProperty annotation.
- Updates the object model and parser to handle the new constraint type.
- Adds and updates tests to verify the new functionality.

Closes #71