### PR TITLE
fix naming of input and output parameter in generated templates

### DIFF
--- a/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/GeneratorParser.java
+++ b/template-generator-maven-plugin/src/main/java/org/camunda/community/template/generator/GeneratorParser.java
@@ -347,7 +347,8 @@ public class GeneratorParser {
       if (!bindingNameFromAnnotation.isBlank()) {
         bindingName = bindingNameFromAnnotation;
       } else {
-        bindingName = fieldInfo.getName();
+        Object constantValue = fieldInfo.getConstantInitializerValue();
+        bindingName = constantValue != null ? String.valueOf(constantValue) : fieldInfo.getName();
       }
 
       String scriptFormat = String.valueOf(fieldParameters.get(SCRIPT_FORMAT));

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/GeneratorTest.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/GeneratorTest.java
@@ -154,7 +154,7 @@ class GeneratorTest {
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of a property");
     templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
-    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "test"));
+    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "testValue"));
     templatePropertyExample.setEditable(false);
     Constraint constraint = new Constraint();
     constraint.setNotEmpty(true);
@@ -189,7 +189,7 @@ class GeneratorTest {
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of a property");
     templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
-    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "test"));
+    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "testValue"));
     templatePropertyExample.setEditable(false);
     templatePropertyExample.setConstraint(constraint);
 
@@ -259,7 +259,7 @@ class GeneratorTest {
     templatePropertyExample.setValue("example");
     templatePropertyExample.setDescription("Example of a property");
     templatePropertyExample.setDocumentationRef("https://docs.camunda.io");
-    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "test"));
+    templatePropertyExample.setBinding(new Binding("camunda:inputParameter", "testValue"));
     templatePropertyExample.setEditable(false);
     Constraint constraint1 = new Constraint();
     constraint1.setNotEmpty(true);
@@ -412,7 +412,7 @@ class GeneratorTest {
     prop1.setLabel("Property with pattern");
     prop1.setType(TemplateProperty.STRING);
     prop1.setEditable(true);
-    prop1.setBinding(new Binding(INPUT_PARAMETER, "propertyWithPattern"));
+    prop1.setBinding(new Binding(INPUT_PARAMETER, "prop1"));
     Constraint constraint1 = new Constraint();
     constraint1.setPattern(
         new org.camunda.community.template.generator.objectmodel.Pattern(
@@ -423,7 +423,7 @@ class GeneratorTest {
     prop2.setLabel("Property with pattern and notEmpty");
     prop2.setType(TemplateProperty.STRING);
     prop2.setEditable(true);
-    prop2.setBinding(new Binding(INPUT_PARAMETER, "propertyWithPatternAndNotEmpty"));
+    prop2.setBinding(new Binding(INPUT_PARAMETER, "prop2"));
     Constraint constraint2 = new Constraint();
     constraint2.setNotEmpty(true);
     constraint2.setPattern(

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/duplicatetemplateid/TestDuplicateTemplateID.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/duplicatetemplateid/TestDuplicateTemplateID.java
@@ -6,7 +6,7 @@ import org.camunda.community.template.generator.test.template.TestTemplate;
 
 public class TestDuplicateTemplateID extends TestTemplate {
 
-  String test = "test";
+  static final String TEST_PARAM = "testValue";
 
   @Template(
       name = "Example", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/template/TestTemplate.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/template/TestTemplate.java
@@ -5,7 +5,7 @@ import org.camunda.community.template.generator.TemplateProperty;
 
 public class TestTemplate {
 
-  String test = "test";
+  static final String TEST_PARAM = "testValue";
 
   @Template(
       name = "Example", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templateexternaltask/TestTemplateExternalTask.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templateexternaltask/TestTemplateExternalTask.java
@@ -5,7 +5,7 @@ import org.camunda.community.template.generator.TemplateProperty;
 
 public class TestTemplateExternalTask {
 
-  String test = "test";
+  static final String TEST_PARAM = "testValue";
 
   @Template(
       name = "External Task Example", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatemixed/TestTemplateMixed.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatemixed/TestTemplateMixed.java
@@ -14,7 +14,7 @@ public class TestTemplateMixed {
       value = "example", //
       notEmpty = true, //
       isEditable = false)
-  String test = "test";
+  static final String TEST_PARAM = "testValue";
 
   @Template(
       name = "Example", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatemultiple/TestTemplateMultiple.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatemultiple/TestTemplateMultiple.java
@@ -14,7 +14,7 @@ public class TestTemplateMultiple {
       value = "example", //
       notEmpty = true, //
       isEditable = false)
-  String test = "test";
+  static final String TEST_PARAM = "testValue";
 
   @Template(
       name = "ExampleOne", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templateparameters/TestTemplateParameters.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templateparameters/TestTemplateParameters.java
@@ -16,7 +16,7 @@ public class TestTemplateParameters {
       value = "example", //
       notEmpty = true, //
       isEditable = false)
-  String test = "test";
+  static final String TEST_PARAM = "testValue";
 
   @Template(
       name = "Example", //

--- a/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatepattern/TestTemplatePattern.java
+++ b/template-generator-maven-plugin/src/test/java/org/camunda/community/template/generator/test/templatepattern/TestTemplatePattern.java
@@ -10,7 +10,7 @@ public class TestTemplatePattern {
       type = TemplateProperty.STRING,
       pattern = "^[a-zA-Z0-9]+$",
       patternErrorMessage = "Only alphanumeric characters are allowed.")
-  String propertyWithPattern = "prop1";
+  static final String PROPERTY_WITH_PATTERN = "prop1";
 
   @TemplateProperty(
       label = "Property with pattern and notEmpty",
@@ -18,7 +18,7 @@ public class TestTemplatePattern {
       notEmpty = true,
       pattern = "^\\d{4}$",
       patternErrorMessage = "Must be a 4-digit number.")
-  String propertyWithPatternAndNotEmpty = "prop2";
+  static final String PROPERTY_WITH_PATTERN_AND_NOT_EMPTY = "prop2";
 
   @Template(
       name = "Pattern Example",

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMixedTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMixedTemplates.json
@@ -46,7 +46,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "test"
+          "name": "testValue"
         }
       },
       {

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMultipleTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateMultipleTemplates.json
@@ -46,7 +46,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "test"
+          "name": "testValue"
         }
       },
       {
@@ -104,7 +104,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "test"
+          "name": "testValue"
         }
       },
       {

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateParametersTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplateParametersTemplates.json
@@ -37,7 +37,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "test"
+          "name": "testValue"
         }
       },
       {

--- a/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplatePatternTemplates.json
+++ b/template-generator-maven-plugin/src/test/resources/test-expected/TestTemplatePatternTemplates.json
@@ -20,7 +20,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "propertyWithPattern"
+          "name": "prop1"
         }
       },
       {
@@ -36,7 +36,7 @@
         },
         "binding": {
           "type": "camunda:inputParameter",
-          "name": "propertyWithPatternAndNotEmpty"
+          "name": "prop2"
         }
       },
       {


### PR DESCRIPTION
fix naming of input and output parameter in generated templates by using fieldInfo.getConstantInitializerValue() instead of fieldInfo.getName().